### PR TITLE
mutagen.Rile fail when format is mpeg adts, aac, v4 lc, 44.1 khz, mon…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycryptodome
 wasmer
 python-magic-bin
 wasmer_compiler_cranelift
+python-ffmpeg


### PR DESCRIPTION
mutagen.File fail when format is mpeg adts, aac, v4 lc, 44.1 khz，and  mutagen.File can not handle mpeg adts format
try use ffmpeg to convert it to m4a(need install python-ffmpeg and ffmpeg.exe in your path)